### PR TITLE
Refactor image handling in TreeApiClient and mock API

### DIFF
--- a/apps/api/services/tree-api-client.ts
+++ b/apps/api/services/tree-api-client.ts
@@ -57,7 +57,7 @@ export class TreeApiClient {
     const shouldNormalize =
       this.shouldPreferImageProxy() &&
       Array.isArray(response.entities_list) &&
-      response.entities_list.some(e => e?.properties_list?.originalImg);
+      response.entities_list.some(e => e?.properties_list?.thumbnail);
 
     const entities = shouldNormalize
       ? this.normalizeImageUrls(response.entities_list)
@@ -105,7 +105,7 @@ export class TreeApiClient {
     const base = this.processedBaseUrl || this.processBaseUrl(this.baseUrl);
 
     return entities.map(entity => {
-      if (entity?.properties_list?.originalImg) {
+      if (entity?.properties_list?.thumbnail) {
         const preferredImageUrl = `${base}/api/image/${entity.exclusive_id.dataStore}/${entity.exclusive_id.tableId}`;
         return {
           ...entity,

--- a/apps/api/types/image-api-types.ts
+++ b/apps/api/types/image-api-types.ts
@@ -5,7 +5,7 @@ export interface ImageServiceParams {
 }
 
 export interface ImageServiceResponse {
-  imageUrl: string;
+  thumbnail: string;
   success: boolean;
   error?: string;
 }

--- a/apps/mockapi/image-api-logic.js
+++ b/apps/mockapi/image-api-logic.js
@@ -2,7 +2,12 @@
 function generateMockImageUrl(exclusiveId) {
   const { dataStore = 'default', tableId = 'unknown' } = exclusiveId;
   
-  return `https://picsum.photos/400/300?random=${dataStore}-${tableId}`;
+  // Generate different sizes based on the entity ID
+  const hash = (dataStore + tableId).split('').reduce((acc, char) => acc + char.charCodeAt(0), 0);
+  const width = 300 + (hash % 5) * 100; // 300, 400, 500, 600, 700
+  const height = 200 + (hash % 4) * 50; // 200, 250, 300, 350
+  
+  return `https://picsum.photos/${width}/${height}?random=${dataStore}-${tableId}`;
 }
 
 module.exports = {

--- a/apps/mockapi/index.ts
+++ b/apps/mockapi/index.ts
@@ -190,7 +190,7 @@ function generateMockTableEntities(tableId: string, from: number = 1, to: number
         category: `category-${i % 3}`,
         sortBy: sortBy,
         imageId: "trump_gaza_001",
-        originalImg: `https://picsum.photos/400/300?random=${tableId}-${i}`
+        thumbnail: `https://picsum.photos/${300 + (i % 5) * 100}/${200 + (i % 4) * 50}?random=${tableId}-${i}`
       }
     });
   }
@@ -247,7 +247,7 @@ function generateMockAllTableEntities(tableId: string, _pageSize: number = 100, 
         category: `category-${i % 3}`,
         sortBy: sortBy,
         imageId: "trump_gaza_002",
-        originalImg: `https://picsum.photos/400/300?random=${tableId}-${i}`
+        thumbnail: `https://picsum.photos/${300 + (i % 5) * 100}/${200 + (i % 4) * 50}?random=${tableId}-${i}`
       }
     });
   }
@@ -358,7 +358,7 @@ app.post('/api/image', ({ body: { exclusiveId, link } }: any, res: any) => {
       return res.status(400).json({
         success: false,
         error: 'exclusiveId and link are required',
-        imageUrl: '',
+        thumbnail: '',
       });
     }
 
@@ -369,13 +369,17 @@ app.post('/api/image', ({ body: { exclusiveId, link } }: any, res: any) => {
       const hash = entityId.split('').reduce((acc: number, char: string) => acc + char.charCodeAt(0), 0);
       const imageIndex = hash % 5;
       
+      // Generate different sizes based on the hash
+      const width = 300 + (hash % 5) * 100; // 300, 400, 500, 600, 700
+      const height = 200 + (hash % 4) * 50; // 200, 250, 300, 350
+      
       // Add some randomness to make it more realistic
       const randomSeed = Math.floor(Math.random() * 1000);
-      const imageUrl = `https://picsum.photos/400/300?random=${imageIndex + randomSeed}`;
+      const imageUrl = `https://picsum.photos/${width}/${height}?random=${imageIndex + randomSeed}`;
       
       res.json({
         success: true,
-        imageUrl,
+        thumbnail: imageUrl,
         error: null,
       });
     }, 100 + Math.random() * 200); // Random delay between 100-300ms
@@ -384,7 +388,7 @@ app.post('/api/image', ({ body: { exclusiveId, link } }: any, res: any) => {
     res.status(500).json({
       success: false,
       error: 'Internal server error',
-      imageUrl: '',
+      thumbnail: '',
     });
   }
 });

--- a/apps/mockapi/server.js
+++ b/apps/mockapi/server.js
@@ -96,7 +96,7 @@ app.post('/api/image', (req, res) => {
     return res.status(400).json({
       success: false,
       error: 'exclusiveId is required',
-      imageUrl: '',
+      thumbnail: '',
     });
   }
 
@@ -112,7 +112,7 @@ app.post('/api/image', (req, res) => {
       
       res.json({
         success: true,
-        imageUrl,
+        thumbnail: imageUrl,
         error: null,
       });
     } catch (error) {
@@ -120,7 +120,7 @@ app.post('/api/image', (req, res) => {
       res.status(500).json({
         success: false,
         error: 'Internal server error',
-        imageUrl: '',
+        thumbnail: '',
       });
     }
   }, processingDelay);

--- a/apps/mockapi/tree-api-logic.js
+++ b/apps/mockapi/tree-api-logic.js
@@ -106,7 +106,7 @@ function generateMockTableEntities(tableId, from = 1, to = 10, sortBy = 'Creatio
         additionalProp1: `prop1-${tableId}-${i}`,
         additionalProp2: `prop2-${tableId}-${i}`,
         additionalProp3: `prop3-${tableId}-${i}`,
-        originalImg: `https://picsum.photos/400/300?random=${tableId}-${i}`
+        thumbnail: `https://picsum.photos/${300 + (i % 5) * 100}/${200 + (i % 4) * 50}?random=${tableId}-${i}`
       }
     });
   }


### PR DESCRIPTION
- Update TreeApiClient to use 'thumbnail' instead of 'originalImg' for image normalization.
- Modify ImageServiceResponse to return 'thumbnail' instead of 'imageUrl'.
- Enhance mock image generation logic to create dynamic thumbnail sizes based on entity IDs.
- Update mock API responses to consistently use 'thumbnail' in place of 'imageUrl' for better clarity.